### PR TITLE
feat: Allow async bonk.io injectors

### DIFF
--- a/bonk.io/injector.user.js
+++ b/bonk.io/injector.user.js
@@ -77,7 +77,7 @@
 					for (const injector of window.bonkCodeInjectors) {
 						try {
 							// Run injector from other userscripts
-							if (typeof injector === "function") code = injector(code);
+							if (typeof injector === "function") code = await injector(code);
 							else {
 								log("Injector was not a function");
 								console.log(injector);


### PR DESCRIPTION
This commit allows injectors submitted to window.bonkCodeInjectors to be async functions.

This allows injectors to perform async actions such as `await import` as part of their operation.

Furthermore, this will not break mods written for the non-async version of this injector, since the await keyword will just act like a normal call for those.