### PR TITLE
Fix script crash when website displays 24-hour time format

### DIFF
--- a/student.auckland.ac.nz/uoa-timetable-to-ical.js
+++ b/student.auckland.ac.nz/uoa-timetable-to-ical.js
@@ -309,16 +309,18 @@ This script fetches data from the timetable on SSO (Student Services Online) and
 	 * @param {string} time the time string in the format "HH:MMAM/PM"
 	*/
 	function parseDateTime(date, time) {
+		// 16:00
 		const [day, month, year] = date.split("/").map(Number);
 		const [timePart, meridiem] = time.split(/(?=[AP]M)/i);
 		let [hours, minutes] = timePart.split(":").map(Number);
-
-		// Note: month - 1 because month is zero-indexed in JavaScript
 		const parsedDate = new Date(year, month - 1, day);
-		if (meridiem.toLowerCase() === "pm" && hours < 12) {
-			hours += 12;
-		} else if (meridiem.toLowerCase() === "am" && hours === 12) {
-			hours = 0;
+		// Note: month - 1 because month is zero-indexed in JavaScript
+		if (meridiem !== undefined){
+			if (meridiem.toLowerCase() === "pm" && hours < 12) {
+				hours += 12;
+			} else if (meridiem.toLowerCase() === "am" && hours === 12) {
+				hours = 0;
+			}
 		}
 
 		parsedDate.setHours(hours, minutes);

--- a/student.auckland.ac.nz/uoa-timetable-to-ical.js
+++ b/student.auckland.ac.nz/uoa-timetable-to-ical.js
@@ -309,13 +309,13 @@ This script fetches data from the timetable on SSO (Student Services Online) and
 	 * @param {string} time the time string in the format "HH:MMAM/PM"
 	*/
 	function parseDateTime(date, time) {
-		// 16:00
 		const [day, month, year] = date.split("/").map(Number);
 		const [timePart, meridiem] = time.split(/(?=[AP]M)/i);
 		let [hours, minutes] = timePart.split(":").map(Number);
 		const parsedDate = new Date(year, month - 1, day);
 		// Note: month - 1 because month is zero-indexed in JavaScript
 		if (meridiem !== undefined){
+			// Note: meridiem will return undefined if the SSO website displays time in 24 hours.
 			if (meridiem.toLowerCase() === "pm" && hours < 12) {
 				hours += 12;
 			} else if (meridiem.toLowerCase() === "am" && hours === 12) {


### PR DESCRIPTION
This pull request resolves an issue where the userscript would crash when the SSO website displayed time in the 24-hour format. The problem occurred as meridiem would return `undefined` if the time were displayed in 24-hour time, causing `meridiem.toLowerCase()` to throw an error.

The fix including adding an if statement to check if `meridiem` was undefined.