### PR TITLE
Read course code from event title instead of description

### DIFF
--- a/student.auckland.ac.nz/uoa-timetable-proxy.js
+++ b/student.auckland.ac.nz/uoa-timetable-proxy.js
@@ -67,7 +67,7 @@ I haven't tested this yet. No clue if it actually works.
 
 			if (prevSummary) {
 				const moduleCode = prevSummary.split("/")[0].trim();
-				if (/\b[A-Z]+\s\d{3}\b/.test(moduleCode)) {
+				if (/\b[A-Z]+\s\d{3}[A-Z]?\b/.test(moduleCode)) {
 					parsed.set("moduleusertext2", moduleCode);
 				}
 			}

--- a/student.auckland.ac.nz/uoa-timetable-proxy.js
+++ b/student.auckland.ac.nz/uoa-timetable-proxy.js
@@ -66,6 +66,10 @@ I haven't tested this yet. No clue if it actually works.
 			// Extract module code from SUMMARY (everything before the first /)
 
 			if (prevSummary) {
+				// Some courses have multiple course codes. We'll just use the first one here.
+				// Sometimes the number is the same, but the subject is different
+				// Sometimes the subject and number are both different
+				// It's not really worth the space to use it up. If someone does get annoyed, then I can look into it. IMO being able to see the number is more important than the subject.
 				const moduleCode = prevSummary.split("/")[0].trim();
 				if (/\b[A-Z]+\s\d{3}[A-Z]?\b/.test(moduleCode)) {
 					parsed.set("moduleusertext2", moduleCode);

--- a/student.auckland.ac.nz/uoa-timetable-proxy.js
+++ b/student.auckland.ac.nz/uoa-timetable-proxy.js
@@ -57,10 +57,20 @@ I haven't tested this yet. No clue if it actually works.
 		// Matches an event in the iCalendar file.
 		return icsString.replace(/BEGIN:VEVENT([\s\S]*?)END:VEVENT/gm, (event) => {
 			const description = event.match(this.buildFieldRegex("DESCRIPTION"))?.[1];
+			const prevSummary = event.match(this.buildFieldRegex("SUMMARY"))?.[1];
 			const parsed = this.parseDescription(description);
 
 			// Can't find the description field, return the event as is
 			if (description === undefined) return event;
+
+			// Extract module code from SUMMARY (everything before the first /)
+
+			if (prevSummary) {
+				const moduleCode = prevSummary.split("/")[0].trim();
+				if (/\b[A-Z]+\s\d{3}\b/.test(moduleCode)) {
+					parsed.set("moduleusertext2", moduleCode);
+				}
+			}
 
 			// Keys from the DESCRIPTION to be used to replace the SUMMARY/LOCATION field
 			const summaryTemplate = this.defaultSummaryTemplate;


### PR DESCRIPTION
Looks like course code is gone from description, but it is still present in event title. This PR reads the course code from there instead.